### PR TITLE
Relax specific numpy version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='stackfinder',
       zip_safe=False,
       install_requires=[
           'click==4.1',
-          'numpy==1.9.2',
+          'numpy>=1.9.2',
           'scikit-learn==0.16.1',
           'scipy==0.16.0'
       ],


### PR DESCRIPTION
numpy version 1.9.2 doesn't work with [maxrect](https://github.com/planetlabs/maxrect) for me. 

It might also be better to remove version requirements or make them minimum requirements for the other packages as well, similar to maxrect: https://github.com/planetlabs/maxrect/blob/master/setup.py
